### PR TITLE
chore: add comment

### DIFF
--- a/examples/pregenerate.rs
+++ b/examples/pregenerate.rs
@@ -2,6 +2,8 @@
 //!
 //! This example shows how aux data can be generated to set up proofs. Generated data is used by doctests.
 
+// cargo run --example pregenerate --features=__internal_doctest
+
 use anyhow::{Context, Result};
 use rug::{Complete, Integer};
 

--- a/src/no_small_factor.rs
+++ b/src/no_small_factor.rs
@@ -8,6 +8,8 @@
 //! larger than `sqrt(N) * 2^l`, or equivalently no smaller than `sqrt(N) /
 //! 2^l`
 //!
+//! Because of key generation algorithm of optimized paillier, l should be at least 3
+//!
 //! ## Example
 //!
 //! ```rust
@@ -91,6 +93,7 @@ pub use crate::common::{Aux, InvalidProof};
 pub struct SecurityParams {
     /// l in paper, security parameter for bit size of plaintext: it needs to
     /// differ from sqrt(n) not more than by 2^l
+    /// l should be at least 3
     pub l: usize,
     /// Epsilon in paper, slackness parameter
     pub epsilon: usize,


### PR DESCRIPTION
This pull request includes updates to documentation and comments in the codebase to improve clarity and provide additional context for users. The changes primarily focus on examples and parameter explanations.

### Documentation Improvements:

* Added a usage example for running the `pregenerate` example with specific features in `examples/pregenerate.rs`. This provides clearer instructions for users on how to execute the example.

* Expanded the documentation in `src/no_small_factor.rs` to explain that the parameter `l` in the key generation algorithm for optimized Paillier should be at least 3. This clarification helps users understand the constraints on parameter selection.

* Added a comment in the `SecurityParams` struct in `src/no_small_factor.rs` to specify that `l` must be at least 3. This ensures that the constraint is explicitly documented in the code where the parameter is defined.