### PR TITLE
fix: enc-elg challenge

### DIFF
--- a/src/dlog_with_el_gamal_commitment.rs
+++ b/src/dlog_with_el_gamal_commitment.rs
@@ -74,7 +74,7 @@
 //!
 //! If the verification succeeded, verifier can continue communication with prover
 
-use generic_ec::{Curve, Point, Scalar, SecretScalar};
+use generic_ec::{Curve, Point, Scalar};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -266,7 +266,7 @@ pub mod non_interactive {
 
 #[cfg(test)]
 mod test {
-    use generic_ec::{Curve, Point, Scalar, SecretScalar};
+    use generic_ec::{Curve, Point, Scalar};
     use sha2::Digest;
 
     use crate::common::InvalidProofReason;

--- a/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -98,7 +98,7 @@
 //! If the verification succeeded, verifier can continue communication with prover
 
 use fast_paillier::{AnyEncryptionKey, Ciphertext, Nonce, Plaintext};
-use generic_ec::{Curve, Point, SecretScalar, Scalar};
+use generic_ec::{Curve, Point, Scalar};
 use rug::Integer;
 
 #[cfg(feature = "serde")]
@@ -196,7 +196,7 @@ pub mod interactive {
 
     use crate::{
         common::{fail_if, fail_if_ne, InvalidProofReason},
-        BadExponent, Error,
+        Error,
     };
 
     use crate::common::{IntegerExt, InvalidProof};
@@ -243,20 +243,14 @@ pub mod interactive {
 
     /// Compute proof for given data and prior protocol values
     pub fn prove<E: Curve>(
-        data: Data<E>,
+        _data: Data<E>,
         pdata: PrivateData<E>,
         private_commitment: &PrivateCommitment<E>,
         challenge: &Challenge,
     ) -> Result<Proof<E>, Error> {
         let z1 = (&private_commitment.alpha + (challenge * pdata.plaintext)).complete();
-        let z2 = {
-            let nonce_to_challenge_mod_n: Integer = pdata
-                .nonce
-                .pow_mod_ref(challenge, data.key.n())
-                .ok_or(BadExponent::undefined())?
-                .into();
-            (&private_commitment.r * nonce_to_challenge_mod_n).modulo(data.key.n())
-        };
+        // TODO: recheck
+        let z2 = (&private_commitment.r + (challenge * pdata.nonce)).complete();
         let z3 = (&private_commitment.gamma + (challenge * &private_commitment.mu)).complete();
         let w = private_commitment.beta + (challenge.to_scalar() * pdata.b);
         Ok(Proof { z1, z2, z3, w })

--- a/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -116,6 +116,9 @@ pub struct SecurityParams {
     pub l: usize,
     /// $\varepsilon$ in paper, slackness parameter
     pub epsilon: usize,
+    /// q in paper. Security parameter for challenge
+    #[udigest(as = crate::common::encoding::Integer)]
+    pub q: Integer,
 }
 
 /// Public data that both parties know
@@ -313,8 +316,8 @@ pub mod interactive {
     /// Generate random challenge
     ///
     /// `security` parameter is used to generate challenge in correct range
-    pub fn challenge<E: Curve>(rng: &mut impl RngCore) -> Challenge {
-        Integer::from_rng_pm(&Integer::curve_order::<E>(), rng)
+    pub fn challenge<R: RngCore>(security: &SecurityParams, rng: &mut R) -> Challenge {
+        Integer::from_rng_pm(&security.q, rng)
     }
 }
 
@@ -376,7 +379,7 @@ pub mod non_interactive {
             commitment,
         });
         let mut rng = rand_hash::HashRng::<D, _>::from_seed(seed);
-        super::interactive::challenge::<E>(&mut rng)
+        super::interactive::challenge(security, &mut rng)
     }
 }
 
@@ -432,6 +435,7 @@ mod test {
         let security = super::SecurityParams {
             l: 1024,
             epsilon: 300,
+            q: (Integer::ONE << 128_u32).complete() - 1,
         };
         let plaintext = Integer::from_rng_pm(&(Integer::ONE << security.l).complete(), &mut rng);
         run_with::<C, D>(&mut rng, security, plaintext).expect("proof failed");
@@ -442,6 +446,7 @@ mod test {
         let security = super::SecurityParams {
             l: 1024,
             epsilon: 300,
+            q: (Integer::ONE << 128_u32).complete() - 1,
         };
         let plaintext = (Integer::ONE << (security.l + security.epsilon)).complete() + 1;
         let r = run_with::<C, D>(&mut rng, security, plaintext).expect_err("proof should not pass");


### PR DESCRIPTION
This pull request includes several updates to the cryptographic modules, focusing on removing unused imports, modifying the `SecurityParams` structure, and updating the proof generation and challenge computation logic. These changes improve maintainability, enhance security parameter handling, and simplify the proof computation process.

### Code cleanup and import updates:
* Removed the unused `SecretScalar` import from `generic_ec` in the files `src/dlog_with_el_gamal_commitment.rs` and `src/paillier_encryption_in_range_with_el_gamal.rs`, reducing unnecessary dependencies. [[1]](diffhunk://#diff-7aa765411bf0a45acb614221516ae7b7306704fd18bb9b582b45acc34eb4198aL77-R77) [[2]](diffhunk://#diff-7aa765411bf0a45acb614221516ae7b7306704fd18bb9b582b45acc34eb4198aL269-R269) [[3]](diffhunk://#diff-bbffe36637a50577deb333d254ef364069de36dcc3057ee9425a325adf5dccf5L101-R101)

### Security parameter enhancements:
* Added a new field `q` to the `SecurityParams` struct, representing the security parameter for challenges, and ensured it is properly encoded using `udigest`. This improves the flexibility and security of the parameter configuration.
* Updated test cases to include the new `q` parameter in `SecurityParams` initialization, ensuring compatibility with the updated structure. [[1]](diffhunk://#diff-bbffe36637a50577deb333d254ef364069de36dcc3057ee9425a325adf5dccf5R438) [[2]](diffhunk://#diff-bbffe36637a50577deb333d254ef364069de36dcc3057ee9425a325adf5dccf5R449)

### Proof computation updates:
* Simplified the computation of `z2` in the `prove` function by replacing the modular exponentiation approach with a direct computation using `challenge * pdata.nonce`. Added a TODO comment for further verification of this change.

### Challenge generation updates:
* Modified the `challenge` function to use the new `q` parameter from `SecurityParams` instead of relying on the curve order, allowing for more flexible challenge generation. [[1]](diffhunk://#diff-bbffe36637a50577deb333d254ef364069de36dcc3057ee9425a325adf5dccf5L322-R320) [[2]](diffhunk://#diff-bbffe36637a50577deb333d254ef364069de36dcc3057ee9425a325adf5dccf5L385-R382)

### Code cleanup in error handling:
* Removed the unused `BadExponent` error type from the `interactive` module, simplifying the error-handling code.